### PR TITLE
Increase PDF size limit and add CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Convert PDF files to Markdown instantly, securely, and 100% in your browser. No 
 - **Yes!** Everything happens in your browser. No data is uploaded or stored anywhere.
 
 ### Is there a file size limit?
-- For best performance, keep files under 10MB. Larger files may slow down your browser.
+- For best performance, keep files under 75MB. Larger files may slow down your browser.
 
 ### Can I use this tool offline?
 - Yes! Once loaded, the app works without an internet connection.
@@ -97,6 +97,12 @@ Convert PDF files to Markdown instantly, securely, and 100% in your browser. No 
    yarn dev
    ```
 4. Open [http://localhost:3000](http://localhost:3000) in your browser
+
+### Command-line conversion
+Convert a PDF directly without the browser:
+```bash
+pnpm convert <input.pdf> <output.md>
+```
 
 ---
 

--- a/components/faq-section.tsx
+++ b/components/faq-section.tsx
@@ -69,7 +69,7 @@ export function FaqSection() {
             <AccordionTrigger>Is there a file size limit?</AccordionTrigger>
             <AccordionContent>
               <p>
-                Yes, the recommended maximum file size is 10MB. Larger files may cause performance issues or browser
+                Yes, the recommended maximum file size is 75MB. Larger files may cause performance issues or browser
                 slowdowns. Since all processing happens in your browser, very large files might cause your browser to
                 become unresponsive.
               </p>

--- a/components/file-uploader.tsx
+++ b/components/file-uploader.tsx
@@ -88,9 +88,9 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
   }
 
   const handleFile = (file: File) => {
-    if (file.size > 10 * 1024 * 1024) {
-      // 10MB limit
-      setError("File size exceeds 10MB limit")
+    if (file.size > 75 * 1024 * 1024) {
+      // 75MB limit
+      setError("File size exceeds 75MB limit")
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "convert": "node scripts/pdf2md-cli.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/pdf2md-cli.js
+++ b/scripts/pdf2md-cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const pdf2md = require('@opendocsg/pdf2md');
+
+async function main() {
+  const [,, input, output] = process.argv;
+  if (!input) {
+    console.error('Usage: node scripts/pdf2md-cli.js <input.pdf> [output.md]');
+    process.exit(1);
+  }
+  try {
+    const buffer = fs.readFileSync(path.resolve(input));
+    const markdown = await pdf2md(buffer);
+    if (output) {
+      fs.writeFileSync(path.resolve(output), markdown);
+    } else {
+      process.stdout.write(markdown);
+    }
+  } catch (err) {
+    console.error('Error converting PDF:', err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- bump max file size in the uploader to 75MB
- update FAQ and README with new limit and command-line instructions
- add simple CLI script for local conversions
- expose CLI via `npm run convert`

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684f5589078083248f36ab6941ca302f