### PR TITLE
Add global error handling with toasts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import { Analytics } from '@vercel/analytics/react'
+import { Toaster } from '@/components/ui/sonner'
+import ErrorBoundary from '@/components/error-boundary'
 
 export const metadata: Metadata = {
   title: 'PDF to Markdown Converter – Free Unlimited, Secure, 100% Browser-Based',
@@ -81,7 +83,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        {children}
+        <ErrorBoundary>
+          {children}
+        </ErrorBoundary>
+        <Toaster richColors />
         <Analytics />
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { FileText, Code, ArrowRight} from "lucide-react"
 import { FaqSection } from "@/components/faq-section"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { GitHubStarButton } from "@/components/github-star-button"
+import { toast } from "sonner"
 
 export default function Home() {
   const [markdown, setMarkdown] = useState<string | null>(null)
@@ -87,7 +88,7 @@ export default function Home() {
                   <Button
                     onClick={() => {
                       navigator.clipboard.writeText(markdown || "")
-                      alert("Markdown copied to clipboard!")
+                      toast.success("Markdown copied to clipboard!")
                     }}
                     className="h-9 font-medium bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400"
                   >

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -1,0 +1,33 @@
+"use client"
+import React from "react"
+import { toast } from "sonner"
+
+type ErrorBoundaryProps = {
+  children: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo)
+    toast.error("An unexpected error occurred")
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/components/file-uploader.tsx
+++ b/components/file-uploader.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card"
 import { Upload, File, AlertCircle } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Progress } from "@/components/ui/progress"
+import { toast } from "sonner"
 
 // Import the PDF2MD library dynamically to avoid SSR issues
 import dynamic from "next/dynamic"
@@ -68,7 +69,9 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
       if (file.type === "application/pdf") {
         handleFile(file)
       } else {
-        setError("Please upload a PDF file")
+        const msg = "Please upload a PDF file"
+        setError(msg)
+        toast.error(msg)
       }
     }
   }
@@ -82,7 +85,9 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
       if (file.type === "application/pdf") {
         handleFile(file)
       } else {
-        setError("Please upload a PDF file")
+        const msg = "Please upload a PDF file"
+        setError(msg)
+        toast.error(msg)
       }
     }
   }
@@ -90,7 +95,9 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
   const handleFile = (file: File) => {
     if (file.size > 75 * 1024 * 1024) {
       // 75MB limit
-      setError("File size exceeds 75MB limit")
+      const msg = "File size exceeds 75MB limit"
+      setError(msg)
+      toast.error(msg)
       return
     }
 
@@ -108,7 +115,9 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
       // This is just a placeholder for the button click handler
     } catch (error) {
       console.error("Error converting PDF:", error)
-      setError("Failed to convert PDF. Please try a different file.")
+      const msg = "Failed to convert PDF. Please try a different file."
+      setError(msg)
+      toast.error(msg)
       setIsConverting(false)
     }
   }
@@ -125,10 +134,12 @@ export function FileUploader({ onConversionComplete, isConverting, setIsConverti
             setProgress(100)
             onConversionComplete(markdown, selectedFile)
             setIsConverting(false)
+            toast.success("Conversion complete!")
           }
         }}
         onError={(errorMsg) => {
           setError(errorMsg)
+          toast.error(errorMsg)
           setIsConverting(false)
         }}
       />

--- a/components/pdf2md-loader.tsx
+++ b/components/pdf2md-loader.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { toast } from "sonner"
 
 interface PDF2MDLoaderProps {
   file: File | null
@@ -23,6 +24,7 @@ export default function PDF2MDLoader({ file, isConverting, onLoad, onConversionC
         onLoad()
       } catch (error) {
         console.error("Failed to load pdf2md library:", error)
+        toast.error("Failed to load conversion library. Please try again later.")
         onError("Failed to load conversion library. Please try again later.")
       }
     }
@@ -44,8 +46,10 @@ export default function PDF2MDLoader({ file, isConverting, onLoad, onConversionC
 
         // Return the result
         onConversionComplete(markdown)
+        toast.success("Conversion complete!")
       } catch (error) {
         console.error("Error converting PDF:", error)
+        toast.error("Failed to convert PDF. The file might be corrupted or unsupported.")
         onError("Failed to convert PDF. The file might be corrupted or unsupported.")
       }
     }


### PR DESCRIPTION
## Summary
- add ErrorBoundary component to show toast on runtime errors
- install Toaster in root layout and wrap content with error boundary
- show toast notifications during PDF conversion flow
- display success toast when copying markdown

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852afadcc4883249a5c15d40d39b7f5